### PR TITLE
Deploy to pycon.id

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,9 +6,9 @@ export default {
   target: 'static',
 
   // if you hosted your repository not as a base / main repository, else comment it
-  router: {
-    base: '/pyconid2021/'
-  },
+  //   router: {
+  //     base: '/pyconid2021/'
+  //   },
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+pycon.id


### PR DESCRIPTION
Add `CNAME` file in `static` folder, so if we build the web, we still have `CNAME` file in `dist/`

also remove prefix `/pyconid2021/` since we host in `/` if using domain